### PR TITLE
correct file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ export KUBECONFIG=</path/to/kubeconfig>
 Build the docker image to run the placement controller.
 ```sh
 make images
-export IMAGE_NAME=<placement_image_name> # export IMAGE_NAME=quay.io/open-cluster-management-io/placement:latest
+export IMAGE_NAME=<placement_image_name> # export IMAGE_NAME=quay.io/open-cluster-management/placement:latest
 ```
 
 If your are using kind, load image into kind cluster.
 ```sh
-kind load docker-image <placement_image_name> # kind load docker-image quay.io/open-cluster-management-io/placement:latest
+kind load docker-image <placement_image_name> # kind load docker-image quay.io/open-cluster-management/placement:latest
 ```
 
 And then deploy placement manager on cluster


### PR DESCRIPTION
In readme, the file path should be 
`quay.io/open-cluster-management/placement`
instead of 
`quay.io/open-cluster-management-io/placement` 

Here is the file path from docker, no `-io`:

```
[root@suigh71 placement]# docker images
REPOSITORY                                               TAG           IMAGE ID       CREATED             SIZE
quay.io/open-cluster-management/placement                latest        729bf4bc7ed1   About an hour ago   216MB
```

With the current value, error `ImagePullBackOff`  will be reported after command `make deploy-hub`:

```
[root@suigh71 placement]# kubectl -n open-cluster-management-hub get pods
NAME                                                    READY   STATUS             RESTARTS   AGE
cluster-manager-placement-controller-5f58c5b4b8-9rbc2   0/1     ImagePullBackOff   0          11m
```