### PR TITLE
remind user to remove proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN make build-e2e --warn-undefined-variables
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 ENV USER_UID=10001
-
+# If proxy is added here to resolve build issue, remove it in the codes (E.g., call os.Unsetenv at main.go),
+# or the codes will use it and cause an error, the container cannot be started.
 COPY --from=builder /go/src/open-cluster-management.io/placement/placement /
 COPY --from=builder /go/src/open-cluster-management.io/placement/e2e.test /
 RUN microdnf update && microdnf clean all


### PR DESCRIPTION
After adding proxy into the Dockerfile to fix build error, the container cannot be started as it will try to use the proxy to access something.  This ticket will add some comments in the Dockerfile to remind users to remove the proxy in codes to avoid this issue.

The related logs from kind are as following, and we cannot get any error message when running in the pure k8s env, it is very hard to debug:
```
W0723 10:13:12.734963       1 cmd.go:204] Using insecure, self-signed certificates
I0723 10:13:13.328993       1 observer_polling.go:159] Starting file observer
W0723 10:13:38.331024       1 builder.go:209] unable to get owner reference (falling back to namespace): Get "https://10.96.0.1:443/api/v1/namespaces/open-cluster-management-hub/pods": proxyconnect tcp: dial tcp x.x.x.x:1818: i/o timeout
I0723 10:13:38.331288       1 builder.go:240] placement version v0.1.0-2-gf6dbed9-f6dbed9
I0723 10:13:39.629799       1 cmd.go:88] Received SIGTERM or SIGINT signal, shutting down controller.
I0723 10:13:43.330150       1 observer_polling.go:162] Shutting down file observer
```