### PR TITLE
add status output to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,20 @@ Apply the yaml file to create the placement.
 kubectl apply -f placement.yaml
 ```
 
-Check the 'PlacementDecision'created for this placement. It contains all selected clusters in status.
-```
+Check the 'PlacementDecision' created for this placement. It contains all selected clusters in status.
+
+```txt
 kubectl get placementdecisions
 NAME                    AGE
-placement1-decision-1   14s
+placement1-decision-1   2m27s
+
+kubectl describe placementdecisions placement1-decision-1
+......
+Status:
+  Decisions:
+    Cluster Name:  cluster1
+    Reason:
+Events:            <none>
 ```
 
 ### Clean up


### PR DESCRIPTION
Signed-off-by: suigh <suigh@cn.ibm.com>

The readme mentions `It contains all selected clusters in status`, while there is no example for `status` in the current readme. Add related information for this message.