### PR TITLE
Avoid forbidden message in the log of controller

### DIFF
--- a/deploy/hub/clusterrole.yaml
+++ b/deploy/hub/clusterrole.yaml
@@ -5,8 +5,11 @@ metadata:
 rules:
 # Allow controller to get/list/watch/create/delete configmaps
 - apiGroups: [""]
-  resources: ["configmaps"]
+  resources: ["configmaps", "pods"]
   verbs: ["get", "list", "watch", "create", "delete", "update"]
+- apiGroups: ["apps"]
+  resources: ["replicasets"]
+  verbs: ["get", "list"]
 # Allow controller to create/patch/update events
 - apiGroups: ["", "events.k8s.io"]
   resources: ["events"]


### PR DESCRIPTION
In logs of controller, found:
```
W0806 00:23:42.600398       1 builder.go:209] unable to get owner reference (falling back to namespace): pods is forbidden: User "system:serviceaccount:open-cluster-management-hub:cluster-manager-placement-controller-sa" cannot list resource "pods" in API group "" in the namespace "open-cluster-management-hub"
```
seems, the controller framework adopted: `github.com/openshift/library-go/pkg/controller/controllercmd` try to found the owner of the current pod.

BTW, why adopt `github.com/openshift/library-go` rather than `controller-runtime`? by strategy?