### PR TITLE
allow integration test running on real kube cluster

### DIFF
--- a/test/integration-test.mk
+++ b/test/integration-test.mk
@@ -30,3 +30,8 @@ test-integration: ensure-kubebuilder-tools
 	go test -c ./test/integration
 	./integration.test -ginkgo.slowSpecThreshold=15 -ginkgo.v -ginkgo.failFast
 .PHONY: test-integration
+
+test-integration-in-kube: deploy-hub
+	go test -c ./test/integration
+	KUBE_TEST_ENV=false ./integration.test -ginkgo.slowSpecThreshold=15 -ginkgo.v -ginkgo.failFast
+.PHONY: test-integration-in-kube

--- a/test/integration/placement_test.go
+++ b/test/integration/placement_test.go
@@ -49,12 +49,14 @@ var _ = ginkgo.Describe("Placement", func() {
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		// start controller manager
-		var ctx context.Context
-		ctx, cancel = context.WithCancel(context.Background())
-		go controllers.RunControllerManager(ctx, &controllercmd.ControllerContext{
-			KubeConfig:    restConfig,
-			EventRecorder: util.NewIntegrationTestEventRecorder("integration"),
-		})
+		if enableTestEnv {
+			var ctx context.Context
+			ctx, cancel = context.WithCancel(context.Background())
+			go controllers.RunControllerManager(ctx, &controllercmd.ControllerContext{
+				KubeConfig:    restConfig,
+				EventRecorder: util.NewIntegrationTestEventRecorder("integration"),
+			})
+		}
 	})
 
 	ginkgo.AfterEach(func() {


### PR DESCRIPTION
Signed-off-by: haoqing0110 <qhao@redhat.com>

Currently, we don't have an effective way to demo the placement scheduling ability, eg, simulate the cluster resource changes, and observe the placement decision from a real cluster.

The purpose of this PR is, let integration test run on a real kube cluster, makes things easier if want to change the cluster resource, creating some fake placement decision, and observe the result from cluster CR. 

With this PR, you can still run the integration on the test kube env with below command.
```
make test-integration
```
If want to run the integration on a real kube cluster, run with the below command. It supposes you already have a kubecluster, the command will deploy placement-controller and related CRD, then run integration case. 
```
make test-integration-in-kube
```
