### PR TITLE
clean env after e2e test

### DIFF
--- a/test/e2e/placement_test.go
+++ b/test/e2e/placement_test.go
@@ -44,6 +44,14 @@ var _ = ginkgo.Describe("Placement", func() {
 	})
 
 	ginkgo.AfterEach(func() {
+		ginkgo.By("Delete managedclusterset")
+		clusterClient.ClusterV1alpha1().ManagedClusterSets().Delete(context.Background(), clusterSet1Name, metav1.DeleteOptions{})
+
+		ginkgo.By("Delete managedclusters")
+		clusterClient.ClusterV1().ManagedClusters().DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{
+			LabelSelector: clusterSetLabel + "=" + clusterSet1Name,
+		})
+
 		err := kubeClient.CoreV1().Namespaces().Delete(context.Background(), namespace, metav1.DeleteOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	})


### PR DESCRIPTION
Signed-off-by: suigh <suigh@cn.ibm.com>


**The issue:**
After e2e test (make test-e2e), there will be many managedclusters and managedclusterset left in the cluster as following, we should clean them.

```
# kubectl get managedclusters
NAME            HUB ACCEPTED   MANAGED CLUSTER URLS         JOINED   AVAILABLE   AGE
cluster-2nj5x   false                                                            7m
cluster-46hmt   false                                                            20m
cluster-4vpng   false                                                            20m
cluster-5c5j7   false                                                            31m
......

# kubectl get managedclusterset
NAME               AGE
clusterset-6wzqg   13m
clusterset-9hd64   7m6s
clusterset-b5n74   31m
clusterset-cl6gj   20m
......
```

**The solution:**
Clean them in ginkgo.AfterEach

For managedclusterset, as there is already a name for it, clean it directly.
For managedclusters, put the names into a slice managedClusterNames, then clean them one by one.