### PR TITLE
Remind user to deploy placement controller before running some test cases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,17 +59,17 @@ Run integration testing
 make test-integration
 ```
 
+Before running e2e/scalability testing, deploy the placement controller with corresponding steps from [PLACEMENT Doc](https://github.com/open-cluster-management-io/placement#deploy-the-placement-controller).
+
 Run e2e testing.
 ```shell
-go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.1
-
-export KUBECONFIG=</path/to/kubeconfig>
-
-make images
-
-kind load docker-image quay.io/open-cluster-management/placement:latest --name {your cluster name}
-
 make test-e2e
+```
+
+Run scalability testing if your PR has impact on the scalability
+
+```shell
+make test-scalability
 ```
 
 ## Build images

--- a/test/scalability/README.md
+++ b/test/scalability/README.md
@@ -1,0 +1,15 @@
+# Scalability test
+
+## Motivation
+
+Add test cases for scalability, help developers to measure the impact of their fixes on scalability.
+
+## Design Details
+
+### Create a placement with many managedclusters
+
+This test case is used to check whether a placement with many managedclusters can be created within expected time or not. One placement with many managedclusters will be created, and there will be enough candidate managedclusters to ensure there will be competing among these candidates.
+
+### Create/update many placements with many managedclusters
+
+This test case is used to check whether many placements, each with many managedclusters, can be created/updated within expected time or not. Placements with many managedclusters will be created first to check time cost for creating, and then the count of managedclusters will be updated to update the placements, this is used to check the time cost for updating.


### PR DESCRIPTION
Signed-off-by: suigh <suigh@cn.ibm.com>

Update the document, remind user to deploy placement controller before running integration/e2e/scalability cases.