### PR TITLE
Remind user to deploy placement controller before running some test cases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,25 +59,17 @@ Run integration testing
 make test-integration
 ```
 
+Before running e2e/scalability testing, deploy the placement controller with corresponding steps from [PLACEMENT Doc](https://github.com/open-cluster-management-io/placement#deploy-the-placement-controller)
+
 Run e2e testing.
+
 ```shell
-go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.1
-
-export KUBECONFIG=</path/to/kubeconfig>
-
-make images
-
-kind load docker-image quay.io/open-cluster-management/placement:latest --name {your cluster name}
-
 make test-e2e
 ```
 
 Run scalability testing if your PR has impact on the scalability
 
 ```shell
-Deploy the placement controller with corresponding steps from [PLACEMENT Doc](https://github.com/open-cluster-management-io/placement#deploy-the-placement-controller)
-
-
 make test-scalability
 ```
 


### PR DESCRIPTION
Signed-off-by: suigh <suigh@cn.ibm.com>

Branch for #46 is broken, use this ticket to trace the original fix -- Update the document, remind user to deploy placement controller before running integration/e2e/scalability cases.