### PR TITLE
add resync controller 

### DIFF
--- a/pkg/controllers/manager.go
+++ b/pkg/controllers/manager.go
@@ -16,6 +16,8 @@ import (
 	"open-cluster-management.io/placement/pkg/debugger"
 )
 
+var ResyncInterval = time.Minute * 5
+
 // RunControllerManager starts the controllers on hub to make placement decisions.
 func RunControllerManager(ctx context.Context, controllerContext *controllercmd.ControllerContext) error {
 	clusterClient, err := clusterclient.NewForConfig(controllerContext.KubeConfig)
@@ -67,7 +69,8 @@ func RunControllerManager(ctx context.Context, controllerContext *controllercmd.
 
 	go clusterInformers.Start(ctx.Done())
 
-	go schedulingController.Run(ctx, 1)
+	go schedulingController.Controller().Run(ctx, 1)
+	go schedulingController.Resync(ResyncInterval, ctx)
 
 	<-ctx.Done()
 	return nil

--- a/test/benchmark/benchmark_test.go
+++ b/test/benchmark/benchmark_test.go
@@ -1,0 +1,153 @@
+package benchmark
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openshift/library-go/pkg/controller/controllercmd"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	clusterv1client "open-cluster-management.io/api/client/cluster/clientset/versioned"
+	clusterapiv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
+	controllers "open-cluster-management.io/placement/pkg/controllers"
+	"open-cluster-management.io/placement/test/integration/util"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+var cfg *rest.Config
+var kubeClient kubernetes.Interface
+var clusterClient clusterv1client.Interface
+
+var namespace, name = "benchmark", "benchmark"
+var noc1 = int32(1)
+
+var benchmarkPlacement = clusterapiv1alpha1.Placement{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: namespace,
+		Name:      name,
+	},
+	Spec: clusterapiv1alpha1.PlacementSpec{
+		NumberOfClusters: &noc1,
+
+		PrioritizerPolicy: clusterapiv1alpha1.PrioritizerPolicy{
+			Mode: clusterapiv1alpha1.PrioritizerPolicyModeExact,
+			Configurations: []clusterapiv1alpha1.PrioritizerConfig{
+				{
+					ScoreCoordinate: &clusterapiv1alpha1.ScoreCoordinate{
+
+						Type: "AddOn",
+						AddOn: &clusterapiv1alpha1.AddOnScore{
+							ResourceName: "demo",
+							ScoreName:    "demo",
+						},
+					},
+					Weight: 1,
+				},
+				{
+					Name:   "ResourceAllocatableCPU",
+					Weight: 1,
+				},
+				{
+					Name:   "ResourceAllocatableMemory",
+					Weight: 1,
+				},
+			},
+		},
+	},
+}
+
+func BenchmarkSchedulePlacements100(b *testing.B) {
+	benchmarkSchedulePlacements(b, 100)
+}
+
+func BenchmarkSchedulePlacements1000(b *testing.B) {
+	benchmarkSchedulePlacements(b, 1000)
+}
+
+func BenchmarkSchedulePlacements10000(b *testing.B) {
+	benchmarkSchedulePlacements(b, 10000)
+}
+
+func BenchmarkSchedulePlacements100000(b *testing.B) {
+	benchmarkSchedulePlacements(b, 100000)
+}
+
+func benchmarkSchedulePlacements(b *testing.B, num int) {
+	var err error
+	ctx, _ := context.WithCancel(context.Background())
+	controllers.ResyncInterval = time.Second * 5
+
+	// start a kube-apiserver
+	testEnv := &envtest.Environment{
+		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths: []string{
+			filepath.Join("../../", "deploy", "hub"),
+		},
+	}
+
+	// prepare client
+	if cfg, err = testEnv.Start(); err != nil {
+		klog.Fatalf("%v", err)
+	}
+	if kubeClient, err = kubernetes.NewForConfig(cfg); err != nil {
+		klog.Fatalf("%v", err)
+	}
+	if clusterClient, err = clusterv1client.NewForConfig(cfg); err != nil {
+		klog.Fatalf("%v", err)
+	}
+
+	// prepare namespace
+	createNamespace(namespace)
+
+	go controllers.RunControllerManager(ctx, &controllercmd.ControllerContext{
+		KubeConfig:    cfg,
+		EventRecorder: util.NewIntegrationTestEventRecorder("integration"),
+	})
+
+	go createPlacements(num)
+	assertPlacements(num)
+}
+
+func createNamespace(namespace string) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
+	}
+	_, err := kubeClient.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+	if err != nil {
+		klog.Fatalf("%v", err)
+	}
+}
+
+func createPlacements(num int) {
+	for i := 0; i < num; i++ {
+		benchmarkPlacement.Name = fmt.Sprintf("%s-%d", name, i)
+		_, err := clusterClient.ClusterV1alpha1().Placements(namespace).Create(context.Background(), &benchmarkPlacement, metav1.CreateOptions{})
+		if err != nil {
+			klog.Fatalf("%v", err)
+		}
+	}
+}
+
+func assertPlacements(num int) {
+	for {
+		actualNum := 0
+		placements, _ := clusterClient.ClusterV1alpha1().Placements(namespace).List(context.Background(), metav1.ListOptions{})
+		for _, v := range placements.Items {
+			if len(v.Status.Conditions) > 0 {
+				actualNum += 1
+			}
+		}
+		if actualNum == num {
+			return
+		}
+		time.Sleep(1 * time.Second)
+	}
+}

--- a/test/integration/placement_test.go
+++ b/test/integration/placement_test.go
@@ -57,6 +57,7 @@ var _ = ginkgo.Describe("Placement", func() {
 		// start controller manager
 		var ctx context.Context
 		ctx, cancel = context.WithCancel(context.Background())
+		controllers.ResyncInterval = time.Second * 5
 		go controllers.RunControllerManager(ctx, &controllercmd.ControllerContext{
 			KubeConfig:    restConfig,
 			EventRecorder: util.NewIntegrationTestEventRecorder("integration"),
@@ -668,6 +669,60 @@ var _ = ginkgo.Describe("Placement", func() {
 			//Checking the result of the placement
 			assertCreatingPlacement(placementName, noc(2), 2, prioritizerPolicy)
 			assertClusterNamesOfDecisions(placementName, []string{clusterNames[1], clusterNames[2]})
+		})
+
+		ginkgo.It("Should reschedule every ResyncInterval and update desicion when AddOnPlacementScore changes", func() {
+			// cluster settings
+			clusterNames := []string{
+				clusterName + "-1",
+				clusterName + "-2",
+				clusterName + "-3",
+			}
+
+			// placement settings
+			prioritizerPolicy := clusterapiv1alpha1.PrioritizerPolicy{
+				Mode: clusterapiv1alpha1.PrioritizerPolicyModeExact,
+				Configurations: []clusterapiv1alpha1.PrioritizerConfig{
+					{
+						ScoreCoordinate: &clusterapiv1alpha1.ScoreCoordinate{
+
+							Type: "AddOn",
+							AddOn: &clusterapiv1alpha1.AddOnScore{
+								ResourceName: "demo",
+								ScoreName:    "demo",
+							},
+						},
+						Weight: 1,
+					},
+				},
+			}
+
+			//Creating the clusters with resources
+			assertBindingClusterSet(clusterSet1Name)
+			assertCreatingClustersWithNames(clusterSet1Name, clusterNames)
+
+			//Creating the placement
+			assertCreatingPlacement(placementName, noc(2), 2, prioritizerPolicy)
+
+			//Checking the result of the placement when no AddOnPlacementScores
+			assertClusterNamesOfDecisions(placementName, []string{clusterNames[0], clusterNames[1]})
+
+			//Creating the AddOnPlacementScores
+			assertCreatingAddOnPlacementScores(clusterNames[0], "demo", "demo", 80)
+			assertCreatingAddOnPlacementScores(clusterNames[1], "demo", "demo", 90)
+			assertCreatingAddOnPlacementScores(clusterNames[2], "demo", "demo", 100)
+
+			//Checking the result of the placement when AddOnPlacementScores added
+			assertClusterNamesOfDecisions(placementName, []string{clusterNames[1], clusterNames[2]})
+
+			//update the AddOnPlacementScores
+			assertCreatingAddOnPlacementScores(clusterNames[0], "demo", "demo", 100)
+			assertCreatingAddOnPlacementScores(clusterNames[1], "demo", "demo", 90)
+			assertCreatingAddOnPlacementScores(clusterNames[2], "demo", "demo", 100)
+
+			//Checking the result of the placement when AddOnPlacementScores updated
+			assertClusterNamesOfDecisions(placementName, []string{clusterNames[0], clusterNames[2]})
+
 		})
 
 		ginkgo.It("Should keep steady successfully even placementdecisions' balance and cluster situation changes", func() {

--- a/test/integration/placement_test.go
+++ b/test/integration/placement_test.go
@@ -19,6 +19,7 @@ import (
 	clusterapiv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
 	clusterapiv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
 	controllers "open-cluster-management.io/placement/pkg/controllers"
+	scheduling "open-cluster-management.io/placement/pkg/controllers/scheduling"
 	"open-cluster-management.io/placement/test/integration/util"
 )
 
@@ -57,7 +58,7 @@ var _ = ginkgo.Describe("Placement", func() {
 		// start controller manager
 		var ctx context.Context
 		ctx, cancel = context.WithCancel(context.Background())
-		controllers.ResyncInterval = time.Second * 5
+		scheduling.ResyncInterval = time.Second * 5
 		go controllers.RunControllerManager(ctx, &controllercmd.ControllerContext{
 			KubeConfig:    restConfig,
 			EventRecorder: util.NewIntegrationTestEventRecorder("integration"),


### PR DESCRIPTION
The related feature request: open-cluster-management-io/community#52
Ref: https://github.com/open-cluster-management/backlog/issues/18210

Signed-off-by: haoqing0110 <qhao@redhat.com>

In the benchemark testing, then resync interval is 5 seconds, the schedule time of 100000 placements reduce about 20s. 

Before (resync in the same controller with [code](https://github.com/haoqing0110/placement/commit/546eefb94d7621a700677f98a815f66fc33771be))
```
# go test -bench="BenchmarkSchedulePlacements100000$"
goos: linux
goarch: amd64
pkg: open-cluster-management.io/placement/test/benchmark
cpu: Intel Core Processor (Haswell, no TSX)
BenchmarkSchedulePlacements100000-24                   1        279440555550 ns/op
PASS
ok      open-cluster-management.io/placement/test/benchmark     279.802s
-
```

After  (resync in the new controller)
```
#  go test -bench="BenchmarkSchedulePlacements100000$"
goos: linux
goarch: amd64
pkg: open-cluster-management.io/placement/test/benchmark
cpu: Intel Core Processor (Haswell, no TSX)
BenchmarkSchedulePlacements100000-24                   1        255090872924 ns/op
PASS
ok      open-cluster-management.io/placement/test/benchmark     255.366s
```