### PR TITLE
Disable placement scheduling

### DIFF
--- a/deploy/hub/0000_00_clusters.open-cluster-management.io_managedclustersets.crd.yaml
+++ b/deploy/hub/0000_00_clusters.open-cluster-management.io_managedclustersets.crd.yaml
@@ -151,11 +151,12 @@ spec:
                           additionalProperties:
                             type: string
                     selectorType:
-                      description: SelectorType could only be "LegacyClusterSetLabel" or "LabelSelector" "LegacyClusterSetLabel" means to use label "cluster.open-cluster-management.io/clusterset:<ManagedClusterSet Name>"" to select target clusters. "LabelSelector" means use labelSelector to select target managedClusters
+                      description: SelectorType could only be "LegacyClusterSetLabel", "ExclusiveClusterSetLabel" or "LabelSelector" "ExclusiveClusterSetLabel" means to use label "cluster.open-cluster-management.io/clusterset:<ManagedClusterSet Name>"" to select target clusters. "LegacyClusterSetLabel" will be replaced by "ExclusiveClusterSetLabel" future "LabelSelector" means use labelSelector to select target managedClusters
                       type: string
                       default: LegacyClusterSetLabel
                       enum:
                         - LegacyClusterSetLabel
+                        - ExclusiveClusterSetLabel
                         - LabelSelector
             status:
               description: Status represents the current status of the ManagedClusterSet

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	k8s.io/component-base v0.24.3
 	k8s.io/klog/v2 v2.70.1
 	k8s.io/utils v0.0.0-20220713171938-56c0de1e6f5e
-	open-cluster-management.io/api v0.8.0
+	open-cluster-management.io/api v0.8.1-0.20220909075958-efae592d4408
 	sigs.k8s.io/controller-runtime v0.12.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1183,8 +1183,6 @@ k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20220713171938-56c0de1e6f5e h1:W1yba+Bpkwb5BatGKZALQ1yylhwnuD6CkYmrTibyLDM=
 k8s.io/utils v0.0.0-20220713171938-56c0de1e6f5e/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-open-cluster-management.io/api v0.8.0 h1:hQLNyvvdx0G0iNxq80RWp93epNsUtsqJdLmGbXiYG5o=
-open-cluster-management.io/api v0.8.0/go.mod h1:+OEARSAl2jIhuLItUcS30UgLA3khmA9ihygLVxzEn+U=
 open-cluster-management.io/api v0.8.1-0.20220909075958-efae592d4408 h1:0hp7Ye9u6aqBaDiJj6vcPLvVwn/AwE7oES/CZ1YXqK4=
 open-cluster-management.io/api v0.8.1-0.20220909075958-efae592d4408/go.mod h1:+OEARSAl2jIhuLItUcS30UgLA3khmA9ihygLVxzEn+U=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/go.sum
+++ b/go.sum
@@ -1185,6 +1185,8 @@ k8s.io/utils v0.0.0-20220713171938-56c0de1e6f5e h1:W1yba+Bpkwb5BatGKZALQ1yylhwnu
 k8s.io/utils v0.0.0-20220713171938-56c0de1e6f5e/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 open-cluster-management.io/api v0.8.0 h1:hQLNyvvdx0G0iNxq80RWp93epNsUtsqJdLmGbXiYG5o=
 open-cluster-management.io/api v0.8.0/go.mod h1:+OEARSAl2jIhuLItUcS30UgLA3khmA9ihygLVxzEn+U=
+open-cluster-management.io/api v0.8.1-0.20220909075958-efae592d4408 h1:0hp7Ye9u6aqBaDiJj6vcPLvVwn/AwE7oES/CZ1YXqK4=
+open-cluster-management.io/api v0.8.1-0.20220909075958-efae592d4408/go.mod h1:+OEARSAl2jIhuLItUcS30UgLA3khmA9ihygLVxzEn+U=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/controllers/scheduling/scheduling_controller.go
+++ b/pkg/controllers/scheduling/scheduling_controller.go
@@ -36,7 +36,6 @@ import (
 const (
 	clusterSetLabel                = "cluster.open-cluster-management.io/clusterset"
 	placementLabel                 = "cluster.open-cluster-management.io/placement"
-	placementDisableAnnotation     = "cluster.open-cluster-management.io/placement-scheduling-disable"
 	schedulingControllerName       = "SchedulingController"
 	schedulingControllerResyncName = "SchedulingControllerResync"
 	maxNumOfClusterDecisions       = 100
@@ -265,7 +264,7 @@ func (c *schedulingController) syncPlacement(ctx context.Context, syncCtx factor
 	}
 
 	// no work if placement has cluster.open-cluster-management.io/placement-scheduling-disable: "true" annotation
-	if value, ok := placement.GetAnnotations()[placementDisableAnnotation]; ok && value == "true" {
+	if value, ok := placement.GetAnnotations()[clusterapiv1beta1.PlacementDisableAnnotation]; ok && value == "true" {
 		return nil
 	}
 

--- a/pkg/controllers/scheduling/scheduling_controller.go
+++ b/pkg/controllers/scheduling/scheduling_controller.go
@@ -36,6 +36,7 @@ import (
 const (
 	clusterSetLabel                = "cluster.open-cluster-management.io/clusterset"
 	placementLabel                 = "cluster.open-cluster-management.io/placement"
+	placementDisableAnnotation     = "cluster.open-cluster-management.io/placement-scheduling-disable"
 	schedulingControllerName       = "SchedulingController"
 	schedulingControllerResyncName = "SchedulingControllerResync"
 	maxNumOfClusterDecisions       = 100
@@ -260,6 +261,11 @@ func (c *schedulingController) getPlacement(queueKey string) (*clusterapiv1beta1
 func (c *schedulingController) syncPlacement(ctx context.Context, syncCtx factory.SyncContext, placement *clusterapiv1beta1.Placement) error {
 	// no work if placement is deleting
 	if !placement.DeletionTimestamp.IsZero() {
+		return nil
+	}
+
+	// no work if placement has cluster.open-cluster-management.io/placement-scheduling-disable: "true" annotation
+	if value, ok := placement.GetAnnotations()[placementDisableAnnotation]; ok && value == "true" {
 		return nil
 	}
 

--- a/pkg/controllers/scheduling/scheduling_controller.go
+++ b/pkg/controllers/scheduling/scheduling_controller.go
@@ -263,7 +263,7 @@ func (c *schedulingController) syncPlacement(ctx context.Context, syncCtx factor
 		return nil
 	}
 
-	// no work if placement has cluster.open-cluster-management.io/placement-scheduling-disable: "true" annotation
+	// no work if placement has cluster.open-cluster-management.io/experimental-scheduling-disable: "true" annotation
 	if value, ok := placement.GetAnnotations()[clusterapiv1beta1.PlacementDisableAnnotation]; ok && value == "true" {
 		return nil
 	}

--- a/pkg/controllers/scheduling/scheduling_controller_test.go
+++ b/pkg/controllers/scheduling/scheduling_controller_test.go
@@ -180,7 +180,7 @@ func TestSchedulingController_sync(t *testing.T) {
 			name: "placement schedule controller is disabled",
 			placement: testinghelpers.NewPlacementWithAnnotations(placementNamespace, placementName,
 				map[string]string{
-					placementDisableAnnotation: "true",
+					clusterapiv1beta1.PlacementDisableAnnotation: "true",
 				}).Build(),
 			scheduleResult: &scheduleResult{
 				feasibleClusters: []*clusterapiv1.ManagedCluster{

--- a/pkg/controllers/scheduling/scheduling_controller_test.go
+++ b/pkg/controllers/scheduling/scheduling_controller_test.go
@@ -176,6 +176,22 @@ func TestSchedulingController_sync(t *testing.T) {
 			},
 			validateActions: testinghelpers.AssertNoActions,
 		},
+		{
+			name: "placement schedule controller is disabled",
+			placement: testinghelpers.NewPlacementWithAnnotations(placementNamespace, placementName,
+				map[string]string{
+					placementDisableAnnotation: "true",
+				}).Build(),
+			scheduleResult: &scheduleResult{
+				feasibleClusters: []*clusterapiv1.ManagedCluster{
+					testinghelpers.NewManagedCluster("cluster1").Build(),
+					testinghelpers.NewManagedCluster("cluster2").Build(),
+					testinghelpers.NewManagedCluster("cluster3").Build(),
+				},
+				scheduledDecisions: []clusterapiv1beta1.ClusterDecision{},
+			},
+			validateActions: testinghelpers.AssertNoActions,
+		},
 	}
 
 	for _, c := range cases {

--- a/pkg/helpers/testing/builders.go
+++ b/pkg/helpers/testing/builders.go
@@ -29,6 +29,18 @@ func NewPlacement(namespace, name string) *placementBuilder {
 	}
 }
 
+func NewPlacementWithAnnotations(namespace, name string, annotations map[string]string) *placementBuilder {
+	return &placementBuilder{
+		placement: &clusterapiv1beta1.Placement{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:   namespace,
+				Name:        name,
+				Annotations: annotations,
+			},
+		},
+	}
+}
+
 func (b *placementBuilder) WithUID(uid string) *placementBuilder {
 	b.placement.UID = types.UID(uid)
 	return b

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1070,7 +1070,7 @@ k8s.io/utils/path
 k8s.io/utils/pointer
 k8s.io/utils/strings/slices
 k8s.io/utils/trace
-# open-cluster-management.io/api v0.8.0
+# open-cluster-management.io/api v0.8.1-0.20220909075958-efae592d4408
 ## explicit; go 1.18
 open-cluster-management.io/api/client/cluster/clientset/versioned
 open-cluster-management.io/api/client/cluster/clientset/versioned/fake

--- a/vendor/open-cluster-management.io/api/cluster/v1beta1/0000_00_clusters.open-cluster-management.io_managedclustersets.crd.yaml
+++ b/vendor/open-cluster-management.io/api/cluster/v1beta1/0000_00_clusters.open-cluster-management.io_managedclustersets.crd.yaml
@@ -151,11 +151,12 @@ spec:
                           additionalProperties:
                             type: string
                     selectorType:
-                      description: SelectorType could only be "LegacyClusterSetLabel" or "LabelSelector" "LegacyClusterSetLabel" means to use label "cluster.open-cluster-management.io/clusterset:<ManagedClusterSet Name>"" to select target clusters. "LabelSelector" means use labelSelector to select target managedClusters
+                      description: SelectorType could only be "LegacyClusterSetLabel", "ExclusiveClusterSetLabel" or "LabelSelector" "ExclusiveClusterSetLabel" means to use label "cluster.open-cluster-management.io/clusterset:<ManagedClusterSet Name>"" to select target clusters. "LegacyClusterSetLabel" will be replaced by "ExclusiveClusterSetLabel" future "LabelSelector" means use labelSelector to select target managedClusters
                       type: string
                       default: LegacyClusterSetLabel
                       enum:
                         - LegacyClusterSetLabel
+                        - ExclusiveClusterSetLabel
                         - LabelSelector
             status:
               description: Status represents the current status of the ManagedClusterSet

--- a/vendor/open-cluster-management.io/api/cluster/v1beta1/helpers.go
+++ b/vendor/open-cluster-management.io/api/cluster/v1beta1/helpers.go
@@ -81,7 +81,7 @@ func BuildClusterSelector(clusterSet *ManagedClusterSet) (labels.Selector, error
 	selectorType := clusterSet.Spec.ClusterSelector.SelectorType
 
 	switch selectorType {
-	case "", LegacyClusterSetLabel:
+	case "", LegacyClusterSetLabel, ExclusiveClusterSetLabel:
 		return labels.SelectorFromSet(labels.Set{
 			ClusterSetLabel: clusterSet.Name,
 		}), nil

--- a/vendor/open-cluster-management.io/api/cluster/v1beta1/types_managedclusterset.go
+++ b/vendor/open-cluster-management.io/api/cluster/v1beta1/types_managedclusterset.go
@@ -4,7 +4,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//LegacyClusterSetLabel LabelKey
+//ExclusiveClusterSetLabel and LegacyClusterSetLabel LabelKey
 const ClusterSetLabel = "cluster.open-cluster-management.io/clusterset"
 
 // +genclient
@@ -50,10 +50,11 @@ type ManagedClusterSetSpec struct {
 
 // ManagedClusterSelector represents a selector of ManagedClusters
 type ManagedClusterSelector struct {
-	// SelectorType could only be "LegacyClusterSetLabel" or "LabelSelector"
-	// "LegacyClusterSetLabel" means to use label "cluster.open-cluster-management.io/clusterset:<ManagedClusterSet Name>"" to select target clusters.
+	// SelectorType could only be "LegacyClusterSetLabel", "ExclusiveClusterSetLabel" or "LabelSelector"
+	// "ExclusiveClusterSetLabel" means to use label "cluster.open-cluster-management.io/clusterset:<ManagedClusterSet Name>"" to select target clusters.
+	// "LegacyClusterSetLabel" will be replaced by "ExclusiveClusterSetLabel" future
 	// "LabelSelector" means use labelSelector to select target managedClusters
-	// +kubebuilder:validation:Enum=LegacyClusterSetLabel;LabelSelector
+	// +kubebuilder:validation:Enum=LegacyClusterSetLabel;ExclusiveClusterSetLabel;LabelSelector
 	// +kubebuilder:default:=LegacyClusterSetLabel
 	// +required
 	SelectorType SelectorType `json:"selectorType,omitempty"`
@@ -66,7 +67,9 @@ type ManagedClusterSelector struct {
 type SelectorType string
 
 const (
-	// "LegacyClusterSetLabel" means to use label "cluster.open-cluster-management.io/clusterset:<ManagedClusterSet Name>"" to select target clusters.
+	// "ExclusiveClusterSetLabel" means to use label "cluster.open-cluster-management.io/clusterset:<ManagedClusterSet Name>"" to select target clusters.
+	ExclusiveClusterSetLabel SelectorType = "ExclusiveClusterSetLabel"
+	//LegacyClusterSetLabel will be replaced by "ExclusiveClusterSetLabel"
 	LegacyClusterSetLabel SelectorType = "LegacyClusterSetLabel"
 	// "LabelSelector" means use labelSelector to select target managedClusters
 	LabelSelector SelectorType = "LabelSelector"

--- a/vendor/open-cluster-management.io/api/cluster/v1beta1/types_placement.go
+++ b/vendor/open-cluster-management.io/api/cluster/v1beta1/types_placement.go
@@ -292,3 +292,10 @@ type PlacementList struct {
 	// Items is a list of Placements.
 	Items []Placement `json:"items"`
 }
+
+const (
+	// PlacementDisableAnnotation is used to disable scheduling for a placement.
+	// It is a experimental flag to let placement controller ignore this placement,
+	// so other placement consumers can chime in.
+	PlacementDisableAnnotation = "cluster.open-cluster-management.io/experimental-scheduling-disable"
+)

--- a/vendor/open-cluster-management.io/api/cluster/v1beta1/zz_generated.swagger_doc_generated.go
+++ b/vendor/open-cluster-management.io/api/cluster/v1beta1/zz_generated.swagger_doc_generated.go
@@ -13,7 +13,7 @@ package v1beta1
 // AUTO-GENERATED FUNCTIONS START HERE
 var map_ManagedClusterSelector = map[string]string{
 	"":              "ManagedClusterSelector represents a selector of ManagedClusters",
-	"selectorType":  "SelectorType could only be \"LegacyClusterSetLabel\" or \"LabelSelector\" \"LegacyClusterSetLabel\" means to use label \"cluster.open-cluster-management.io/clusterset:<ManagedClusterSet Name>\"\" to select target clusters. \"LabelSelector\" means use labelSelector to select target managedClusters",
+	"selectorType":  "SelectorType could only be \"LegacyClusterSetLabel\", \"ExclusiveClusterSetLabel\" or \"LabelSelector\" \"ExclusiveClusterSetLabel\" means to use label \"cluster.open-cluster-management.io/clusterset:<ManagedClusterSet Name>\"\" to select target clusters. \"LegacyClusterSetLabel\" will be replaced by \"ExclusiveClusterSetLabel\" future \"LabelSelector\" means use labelSelector to select target managedClusters",
 	"labelSelector": "LabelSelector define the general labelSelector which clusterset will use to select target managedClusters",
 }
 


### PR DESCRIPTION
introduce `cluster.open-cluster-management.io/experimental-scheduling-disable` annotation to allow disabling the scheduling. for example, in the global hub case, the global hub controller will propagate the placement to the regional hub cluster. the placement is not designed to run in the cluster where it was created. It is designed to run in the regional hub cluster.

Signed-off-by: clyang82 <chuyang@redhat.com>