### PR TITLE
fix arm image build issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
 FROM golang:1.19 AS builder
+ARG OS=linux
+ARG ARCH=amd64
 WORKDIR /go/src/open-cluster-management.io/placement
 COPY . .
 ENV GO_PACKAGE open-cluster-management.io/placement
 
-RUN make build --warn-undefined-variables
-RUN make build-e2e --warn-undefined-variables
+RUN GOOS=${OS} \
+    GOARCH=${ARCH} \
+    make build --warn-undefined-variables
+RUN GOOS=${OS} \
+    GOARCH=${ARCH} \
+    make build-e2e --warn-undefined-variables
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 ENV USER_UID=10001


### PR DESCRIPTION
Fix the build arm image issue when running on arm64 or mac m1
```
ec2-user@ip-172-31-20-96 ~ % docker run -it quay.io/open-cluster-management/placement:v0.11.0-arm64 sh
sh-4.4$ ./placement
qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
sh-4.4$
```